### PR TITLE
`ead.New()`: validate `repositoryCode` arg

### DIFF
--- a/pkg/ead/ead.go
+++ b/pkg/ead/ead.go
@@ -27,12 +27,22 @@ const numMatchGroupsInNamespaceRegexp = 3
 // https://stackoverflow.com/questions/1587891/is-xmlns-a-valid-xml-namespace
 var namespaceRegexp = regexp.MustCompile(`<((?s)\s*)ead((?s).*)xmlns="(?U).*"`)
 
+// We don't have an official repository code format, but there is a comprehensive
+// list of repository codes:
+// https://jira.nyu.edu/browse/FADESIGN-65
+var validRepositoryCodeRegex = regexp.MustCompile(`^[a-z]+$`)
+
 // Note that the repository code historically is taken from the name of the
 // EAD file's parent directory, not from the anything in the contents of the file
 // itself.  For now we are keeping file handling out of this package, so it is
 // up to the client to pass in the repository code.
 func New(repositoryCode string, eadXML string) (EAD, error) {
 	ead := EAD{}
+
+	if !validRepositoryCodeRegex.MatchString(repositoryCode) {
+		return ead, errors.New(fmt.Sprintf(`Invalid repository code: "%s"`,
+			repositoryCode))
+	}
 
 	// XPath queries fail if we don't set the namespace to empty string.
 	// Excepting the `xlink` prefix, the tags in the EAD files don't seem to use

--- a/pkg/ead/ead_test.go
+++ b/pkg/ead/ead_test.go
@@ -103,6 +103,8 @@ func TestNewWithBadEADXML(t *testing.T) {
 		if err == nil {
 			t.Errorf(`Expected an error to be returned by New("%s", "%s"), but no error was returned.`,
 				repositoryCode, testCase.eadXML)
+
+			continue
 		}
 
 		errorString := err.Error()

--- a/pkg/ead/ead_test.go
+++ b/pkg/ead/ead_test.go
@@ -116,6 +116,47 @@ func TestNewWithBadEADXML(t *testing.T) {
 	}
 }
 
+// We don't have an official repository code format, but there is a comprehensive
+// list of repository codes:
+// https://jira.nyu.edu/browse/FADESIGN-65
+func TestNewWithInvalidRepositoryCode(t *testing.T) {
+	testCases := []struct {
+		repositoryCode string
+		expectedError  string
+	}{
+		{
+			repositoryCode: "",
+			expectedError:  `Invalid repository code: ""`,
+		},
+		{
+			repositoryCode: "!#$",
+			expectedError:  `Invalid repository code: "!#$"`,
+		},
+	}
+
+	eadXML, err := testutils.GetEADFixtureValue("edip/mos_2024")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, testCase := range testCases {
+		_, err := New(testCase.repositoryCode, eadXML)
+		if err == nil {
+			t.Errorf(`Expected an error to be returned by New("%s", "..."), but no error was returned.`,
+				testCase.repositoryCode)
+
+			continue
+		}
+
+		errorString := err.Error()
+		if errorString != testCase.expectedError {
+			t.Errorf(`Expected error "%s" to be returned by New("%s", "..."),`+
+				` but got: "%s"`,
+				testCase.expectedError, testCase.repositoryCode, errorString)
+		}
+	}
+}
+
 func clean() error {
 	err := os.RemoveAll(tmpFilesDirPath)
 	if err != nil {


### PR DESCRIPTION
* Validate `repositoryCode` arg to `ead.New()`
* Add missing `continue` to `[TestNewWithBadEADXML|https://github.com/NYULibraries/go-ead-indexer/commit/b3f3b06d40687e576198b5d81b16af490855e623]`