### PR TITLE
Plug memory leak in `ead`: call `Free()` on results returned from `node.Find()` calls

### DIFF
--- a/pkg/ead/component/ancestor-unit-title.go
+++ b/pkg/ead/component/ancestor-unit-title.go
@@ -19,6 +19,7 @@ func getAncestorUnitTitle(node types.Node) (string, error) {
 	if err != nil {
 		return ancestorUnitTitle, err
 	}
+	defer xpathResult.Free()
 
 	unitTitleNodes := xpathResult.NodeList()
 	if len(unitTitleNodes) > 0 {
@@ -48,6 +49,7 @@ func getAncestorUnitTitle(node types.Node) (string, error) {
 		if err != nil {
 			return ancestorUnitTitle, err
 		}
+		defer xpathResult.Free()
 
 		unitDateNodes := xpathResult.NodeList()
 		if len(unitDateNodes) > 0 {

--- a/pkg/ead/component/component.go
+++ b/pkg/ead/component/component.go
@@ -123,6 +123,7 @@ func MakeComponents(collectionDocParts ComponentCollectionDocParts, node types.N
 	if err != nil {
 		return nil, err
 	}
+	defer xpathResult.Free()
 
 	// Note: can't do `&xpathResult.NodeList()`
 	// See https://groups.google.com/g/golang-nuts/c/reaIlFdibWU

--- a/pkg/ead/component/set-containers-part.go
+++ b/pkg/ead/component/set-containers-part.go
@@ -9,6 +9,7 @@ func (component *Component) setContainersPart(node types.Node) error {
 	if err != nil {
 		return err
 	}
+	defer xpathResult.Free()
 
 	containerNodes := xpathResult.NodeList()
 	for _, containerNode := range containerNodes {

--- a/pkg/ead/eadutil/eadutil.go
+++ b/pkg/ead/eadutil/eadutil.go
@@ -190,6 +190,7 @@ func GetFirstNode(query string, node types.Node) (types.Node, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer xpathResult.Free()
 
 	nodeList := xpathResult.NodeList()
 
@@ -221,6 +222,7 @@ func GetNodeList(query string, node types.Node) (types.NodeList, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer xpathResult.Free()
 
 	return xpathResult.NodeList(), nil
 }
@@ -265,6 +267,7 @@ func GetNodeValuesAndXMLStrings(query string, node types.Node) ([]string, []stri
 	if err != nil {
 		return nil, nil, err
 	}
+	defer xpathResult.Free()
 
 	for _, resultNode := range xpathResult.NodeList() {
 		values = append(values, resultNode.NodeValue())


### PR DESCRIPTION
See [Need to call `Free()` on the result of `Find()` and `FindExpr()` to avoid memory leak](https://jira.nyu.edu/browse/DLFA-264?focusedCommentId=11533641&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-11533641)