### PR TITLE
Use regular, non-static builds for Dockerfile and Dockerfile.test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,7 @@ WORKDIR /app
 
 RUN apt-get update -y && apt-get install -y libxml2-dev pkg-config
 RUN go install golang.org/x/lint/golint@latest
-COPY . . 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o app .
-
-FROM scratch 
-
-WORKDIR /app
-
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /app/app ./eadindexer
+COPY . .
+RUN go build -o eadindexer
 
 ENTRYPOINT [ "./eadindexer" ]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -6,7 +6,6 @@ WORKDIR /app
 
 RUN apt-get update -y && apt-get install -y libxml2-dev pkg-config
 RUN go install golang.org/x/lint/golint@latest
-COPY . . 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o app .
+COPY . .
 
 CMD [ "go", "test", "./...", "-cover" ]


### PR DESCRIPTION
This PR is a fix for [DLFA-266: Resolve build problem for index package on CircleCI|https://jira.nyu.edu/browse/DLFA-266].

* _Dockerfile_:
  * Use `golang:1.23` image instead of `scratch` for execution
  * Replace the static build of the `eadindexer` binary which is currently not working on the parent branch with a regular, non-static build
* _Dockerfile.test_
  * Remove the `RUN` command the does the static build that is currently not working on the parent branch.  No need to replace it with a regular, non-static build because the resulting binary is not actually used, even when the build succeeds.
  