### PR TITLE
pkg/ead/testutils/testutils.go -- update param name for GetGoldenFileIDs(): `eadID` -> `testEAD`

### DIFF
--- a/pkg/ead/testutils/testutils.go
+++ b/pkg/ead/testutils/testutils.go
@@ -44,10 +44,11 @@ func GetEADFixtureValue(testEAD string) (string, error) {
 	return GetTestdataFileContents(EadFixturePath(testEAD))
 }
 
-func GetGoldenFileIDs(eadID string) []string {
+// A "testEAD" is a repository code + "/" + EAD ID.  Example: "edip/mos_2024"
+func GetGoldenFileIDs(testEAD string) []string {
 	goldenFileIDs := []string{}
 
-	err := filepath.WalkDir(filepath.Join(goldenFilesDirPath, eadID),
+	err := filepath.WalkDir(filepath.Join(goldenFilesDirPath, testEAD),
 		func(path string, dirEntry fs.DirEntry, err error) error {
 			if !dirEntry.IsDir() && filepath.Ext(path) == ".xml" {
 				goldenFileIDs = append(goldenFileIDs, strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)))


### PR DESCRIPTION
When `GetGoldenFileIDs()` was first written there were no repository code subdirectories.  Now we need to pass in `testEAD` values, which are [repository code]/[ead id] strings: e.g. "edip/mos_2024".