### PR TITLE
Update initLogger() in cmd/index/index.go

### DIFF
--- a/pkg/cmd/index/index.go
+++ b/pkg/cmd/index/index.go
@@ -84,7 +84,14 @@ func runIndexCmd(cmd *cobra.Command, args []string) error {
 
 // initLogger initializes the logger in the pkg/cmd/index package
 func initLogger() error {
+
 	logger = log.New()
+
+	// set logging level if it was not specified on the command line
+	if loggingLevel == "" {
+		loggingLevel = log.DefaultLevelStringOption
+	}
+
 	normalizedLogLevel := strings.ToLower(loggingLevel)
 	err := logger.SetLevelByString(normalizedLogLevel)
 	if err != nil {

--- a/pkg/cmd/index/index_test.go
+++ b/pkg/cmd/index/index_test.go
@@ -46,6 +46,25 @@ func TestLoggerLevelArgument(t *testing.T) {
 	testutils.CheckStringContains(t, gotStdOut, `Logging level set to \"none\"`)
 }
 
+func TestUnsetLoggingLevelArgument(t *testing.T) {
+	// ensure that the environment variable is set
+	err := os.Setenv("SOLR_ORIGIN_WITH_PORT", "http://www.example.com:8983/solr")
+	if err != nil {
+		t.Errorf("error setting environment variable: %v", err)
+		t.FailNow()
+	}
+
+	testutils.SetCmdFlag(IndexCmd, "file", "testdata/ead.xml")
+	testutils.SetCmdFlag(IndexCmd, "logging-level", "")
+	gotStdOut, _, _ := testutils.CaptureCmdStdoutStderrE(runIndexCmd, IndexCmd, []string{})
+
+	if gotStdOut == "" {
+		t.Errorf("expected data on StdOut but got nothing")
+	}
+
+	testutils.CheckStringContains(t, gotStdOut, `Logging level set to \"info\"`)
+}
+
 func TestMissingFileArgument(t *testing.T) {
 	// ensure that the environment variable is set
 	err := os.Setenv("SOLR_ORIGIN_WITH_PORT", "http://www.example.com:8983/solr")


### PR DESCRIPTION
## Overview

* Update `initLogger()` to handle the case when the logging-level is not
  specified via the command line.

* Add test for indexing behavior when the logging-level is not specified
  via the command line.