### PR TITLE
DLFA-216 :  update valid logging levels

### DIFF
--- a/pkg/cmd/index/index_test.go
+++ b/pkg/cmd/index/index_test.go
@@ -29,6 +29,8 @@ func TestInitLoggerError(t *testing.T) {
 }
 
 func TestLoggerLevelArgument(t *testing.T) {
+	testLogLevel := "debug" // this value MUST BE DIFFERENT from the default logging level
+
 	// ensure that the environment variable is set
 	err := os.Setenv("SOLR_ORIGIN_WITH_PORT", "http://www.example.com:8983/solr")
 	if err != nil {
@@ -37,14 +39,14 @@ func TestLoggerLevelArgument(t *testing.T) {
 	}
 
 	testutils.SetCmdFlag(IndexCmd, "file", "testdata/ead.xml")
-	testutils.SetCmdFlag(IndexCmd, "logging-level", "none")
+	testutils.SetCmdFlag(IndexCmd, "logging-level", testLogLevel)
 	gotStdOut, _, _ := testutils.CaptureCmdStdoutStderrE(runIndexCmd, IndexCmd, []string{})
 
 	if gotStdOut == "" {
 		t.Errorf("expected data on StdOut but got nothing")
 	}
 
-	testutils.CheckStringContains(t, gotStdOut, `Logging level set to \"none\"`)
+	testutils.CheckStringContains(t, gotStdOut, fmt.Sprintf("Logging level set to \\\"%s\\\"", testLogLevel))
 }
 
 func TestUnsetLoggingLevelArgument(t *testing.T) {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math"
 	"os"
 	"reflect"
 	"sort"
@@ -17,9 +16,7 @@ type Level int
 type Logger interface {
 	Debug(args ...any)
 	Error(args ...any)
-	Fatal(args ...any)
 	Info(args ...any)
-	Warn(args ...any)
 
 	SetLevel(level Level)
 	SetLevelByString(levelStringArg string) error
@@ -48,17 +45,13 @@ var DefaultLevelStringOption = GetLevelOptionStringForSlogLevel(defaultSlogLevel
 var (
 	LevelDebug = Level(reflect.ValueOf(slog.LevelDebug).Int())
 	LevelInfo  = Level(reflect.ValueOf(slog.LevelInfo).Int())
-	LevelWarn  = Level(reflect.ValueOf(slog.LevelWarn).Int())
 	LevelError = Level(reflect.ValueOf(slog.LevelError).Int())
-	LevelNone  = Level(math.MaxInt)
 )
 
 var logLevelStringOptions = map[string]Level{
 	"debug": LevelDebug,
 	"info":  LevelInfo,
-	"warn":  LevelWarn,
 	"error": LevelError,
-	"none":  LevelNone,
 }
 
 func New() Logger {
@@ -74,12 +67,6 @@ func (sl *SloggerLogger) Debug(args ...any) {
 
 func (sl *SloggerLogger) Error(args ...any) {
 	sl.slogger.Error(emptyMsg, args...)
-}
-
-func (sl *SloggerLogger) Fatal(args ...any) {
-	sl.Error(fmt.Sprint(args...))
-
-	os.Exit(1)
 }
 
 func (sl *SloggerLogger) Info(args ...any) {

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -44,9 +44,7 @@ func TestGetLevelOptionStringForLogLevel(t *testing.T) {
 	}{
 		{name: "LevelDebug", expectedLevelOptionString: "debug", level: LevelDebug},
 		{name: "LevelInfo", expectedLevelOptionString: "info", level: LevelInfo},
-		{name: "LevelWarn", expectedLevelOptionString: "warn", level: LevelWarn},
 		{name: "LevelError", expectedLevelOptionString: "error", level: LevelError},
-		{name: "LevelNone", expectedLevelOptionString: "none", level: LevelNone},
 	}
 
 	for _, testCase := range testCases {
@@ -64,9 +62,7 @@ func TestGetValidLevelOptionStrings(t *testing.T) {
 	expectedLevelOptionStrings := strings.Join([]string{
 		"debug",
 		"info",
-		"warn",
 		"error",
-		"none",
 	}, "\n")
 
 	actualLevelOptionStrings := strings.Join(GetValidLevelOptionStrings(), "\n")
@@ -84,7 +80,6 @@ func TestSetLevel(t *testing.T) {
 	expectedLogSeriesFull := []string{
 		"DEBUG|debug",
 		"INFO|info",
-		"WARN|warn",
 		"ERROR|error",
 	}
 
@@ -101,9 +96,7 @@ func TestSetLevel(t *testing.T) {
 	}{
 		{name: "Debug", level: LevelDebug},
 		{name: "Info", level: LevelInfo},
-		{name: "Warn", level: LevelWarn},
 		{name: "Error", level: LevelError},
-		{name: "None", level: LevelNone},
 	}
 
 	for i, testCase := range testCases {
@@ -148,7 +141,6 @@ func getLogSeriesString(logOutput string) string {
 func logSeries(logger Logger) {
 	logger.Debug(messageKey, "debug")
 	logger.Info(messageKey, "info")
-	logger.Warn(messageKey, "warn")
 	logger.Error(messageKey, "error")
 }
 


### PR DESCRIPTION
## Overview
This PR removes two logging levels (`warn`, `none`) per the EDIP Tech Meeting of 2025-03-11.
