### PR TITLE
DLFA-216 : limit available logging levels in pkg/cmd/index (redux)

### DIFF
--- a/pkg/cmd/index/index_test.go
+++ b/pkg/cmd/index/index_test.go
@@ -29,6 +29,8 @@ func TestInitLoggerError(t *testing.T) {
 }
 
 func TestLoggerLevelArgument(t *testing.T) {
+	testLogLevel := "debug" // this value MUST BE DIFFERENT from the default logging level
+
 	// ensure that the environment variable is set
 	err := os.Setenv("SOLR_ORIGIN_WITH_PORT", "http://www.example.com:8983/solr")
 	if err != nil {
@@ -37,14 +39,14 @@ func TestLoggerLevelArgument(t *testing.T) {
 	}
 
 	testutils.SetCmdFlag(IndexCmd, "file", "testdata/ead.xml")
-	testutils.SetCmdFlag(IndexCmd, "logging-level", "none")
+	testutils.SetCmdFlag(IndexCmd, "logging-level", testLogLevel)
 	gotStdOut, _, _ := testutils.CaptureCmdStdoutStderrE(runIndexCmd, IndexCmd, []string{})
 
 	if gotStdOut == "" {
 		t.Errorf("expected data on StdOut but got nothing")
 	}
 
-	testutils.CheckStringContains(t, gotStdOut, `Logging level set to \"none\"`)
+	testutils.CheckStringContains(t, gotStdOut, fmt.Sprintf(`Logging level set to \"%s\"`, testLogLevel))
 }
 
 func TestUnsetLoggingLevelArgument(t *testing.T) {

--- a/pkg/cmd/index/index_test.go
+++ b/pkg/cmd/index/index_test.go
@@ -4,10 +4,23 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/nyulibraries/go-ead-indexer/pkg/cmd/testutils"
+	"github.com/nyulibraries/go-ead-indexer/pkg/log"
 )
+
+func TestLocalLogLevels(t *testing.T) {
+	// this is a regression test to ensure that the local log levels are still valid
+	// if this test fails, the local log levels need to be updated
+	loggerAvailableLevels := log.GetValidLevelOptionStrings()
+	for _, level := range localLogLevels {
+		if !slices.Contains(loggerAvailableLevels, level) {
+			t.Errorf("local log level '%s' is not a valid logger level", level)
+		}
+	}
+}
 
 func TestInitLoggerError(t *testing.T) {
 	// ensure that the environment variable is set

--- a/pkg/cmd/index/index_test.go
+++ b/pkg/cmd/index/index_test.go
@@ -25,7 +25,7 @@ func TestInitLoggerError(t *testing.T) {
 		t.Errorf("expected data on StdOut but got nothing")
 	}
 
-	testutils.CheckStringContains(t, gotStdOut, "ERROR: couldn't initialize logger: ERROR: couldn't set log level:")
+	testutils.CheckStringContains(t, gotStdOut, "ERROR: couldn't initialize logger: ERROR: unsupported logging level:")
 }
 
 func TestLoggerLevelArgument(t *testing.T) {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math"
 	"os"
 	"reflect"
 	"sort"
@@ -50,7 +49,6 @@ var (
 	LevelInfo  = Level(reflect.ValueOf(slog.LevelInfo).Int())
 	LevelWarn  = Level(reflect.ValueOf(slog.LevelWarn).Int())
 	LevelError = Level(reflect.ValueOf(slog.LevelError).Int())
-	LevelNone  = Level(math.MaxInt)
 )
 
 var logLevelStringOptions = map[string]Level{
@@ -58,7 +56,6 @@ var logLevelStringOptions = map[string]Level{
 	"info":  LevelInfo,
 	"warn":  LevelWarn,
 	"error": LevelError,
-	"none":  LevelNone,
 }
 
 func New() Logger {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,7 +1,6 @@
 package log
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -95,8 +94,8 @@ func (sl *SloggerLogger) SetLevelByString(levelStringArg string) error {
 		sl.programLevel.Set(slog.Level(level))
 		return nil
 	} else {
-		return errors.New(fmt.Sprintf("\"%s\" is not a valid error string option.  Valid options: %s",
-			levelStringArg, strings.Join(GetValidLevelOptionStrings(), ", ")))
+		return fmt.Errorf("\"%s\" is not a valid error string option.  Valid options: %s",
+			levelStringArg, strings.Join(GetValidLevelOptionStrings(), ", "))
 	}
 }
 

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -46,7 +46,6 @@ func TestGetLevelOptionStringForLogLevel(t *testing.T) {
 		{name: "LevelInfo", expectedLevelOptionString: "info", level: LevelInfo},
 		{name: "LevelWarn", expectedLevelOptionString: "warn", level: LevelWarn},
 		{name: "LevelError", expectedLevelOptionString: "error", level: LevelError},
-		{name: "LevelNone", expectedLevelOptionString: "none", level: LevelNone},
 	}
 
 	for _, testCase := range testCases {
@@ -66,7 +65,6 @@ func TestGetValidLevelOptionStrings(t *testing.T) {
 		"info",
 		"warn",
 		"error",
-		"none",
 	}, "\n")
 
 	actualLevelOptionStrings := strings.Join(GetValidLevelOptionStrings(), "\n")
@@ -103,7 +101,6 @@ func TestSetLevel(t *testing.T) {
 		{name: "Info", level: LevelInfo},
 		{name: "Warn", level: LevelWarn},
 		{name: "Error", level: LevelError},
-		{name: "None", level: LevelNone},
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION
## Overview
This PR limits the logging levels available in `pkg/cmd/index` commands.  This change is per the decision made in the EDIP Tech Meeting of 2025-03-11.