### PR TITLE
Fix `SetLevel*` methods in `log` package

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -84,6 +84,8 @@ func (sl *SloggerLogger) Info(args ...any) {
 
 func (sl *SloggerLogger) SetLevel(level Level) {
 	sl.programLevel.Set(slog.Level(level))
+	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: sl.programLevel})
+	sl.slogger = slog.New(handler)
 }
 
 // Useful for setting the level based on a string value set by a user via a flag
@@ -92,6 +94,9 @@ func (sl *SloggerLogger) SetLevelByString(levelStringArg string) error {
 	level, ok := logLevelStringOptions[levelStringArg]
 	if ok {
 		sl.programLevel.Set(slog.Level(level))
+		handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: sl.programLevel})
+		sl.slogger = slog.New(handler)
+
 		return nil
 	} else {
 		return fmt.Errorf("\"%s\" is not a valid error string option.  Valid options: %s",

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -25,6 +26,16 @@ type setLevelFunction func()
 var simpleLogEntryStringRegexp = regexp.MustCompile(
 	`.*"level":"([A-Z]+)","msg":"","message":"([a-z]+)"}`,
 )
+
+// Originally used `logger.SetOutput([a *bufio.Writer])` in `testSetLevel()`
+// to capture log output, but this hid bugs in  the `SetLevel*` methods,
+// which were not replacing `sl.slogger` with a new `*slog.Logger` that had
+// the new logging level set.  `SetOutput()` was correctly replacing `sl.slogger`
+// with the appropriate new `*slog.Logger`, which is why `testSetLevel()` always passed.
+// We now use the same method employed in pkg/log/cmd/testutils.Capture* functions
+// (written by Joe) to replace `os.Stdout`.
+var stdoutFakeReadFile *os.File
+var stdoutFakeWriteFile *os.File
 
 const messageKey = "message"
 
@@ -103,6 +114,14 @@ func TestSetLevel(t *testing.T) {
 		{name: "Error", level: LevelError},
 	}
 
+	// `os.Stdout` will be replaced by a fake `*File` by the `testSetLevelByLevel*`
+	// functions in the loop below.  Save the original now and restore it after all
+	// tests have completed.
+	origStdout := os.Stdout
+	defer func() {
+		os.Stdout = origStdout
+	}()
+
 	for i, testCase := range testCases {
 		expectedLogSeriesForLevelString := strings.Join(expectedLogSeriesFull[i:], "\n")
 		testSetLevelByLevel(t, testCase.name, testCase.level, expectedLogSeriesForLevelString)
@@ -149,11 +168,30 @@ func logSeries(logger Logger) {
 	logger.Error(messageKey, "error")
 }
 
+// `os.Stdout` has to replaced before any of the `New()` calls in the `testSetLevelByLevel*`
+// helper functions running in the `testCases` loop below, so that the new default
+// loggers will use the fake stdout for their handlers.
+// See var comments for `stdoutFakeReadFile` and `stdoutFakeWriteFile` for more
+// details on why we use this method for capturing logger output rather than simply
+// using `SetOutput()`.
+func resetStdoutFake(t *testing.T) {
+	var err error
+	stdoutFakeReadFile, stdoutFakeWriteFile, err = os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() failed with error: %s", err)
+	}
+	os.Stdout = stdoutFakeWriteFile
+}
+
 // Called in the main loop for `TestSetLevel()`.  It calls the workhorse test function
 // `testSetLevel()`, passing in a closure allowing `testSetLevel()` to set the
 // level without needing to know which setter to use and what level is being
 // specified.  In this case, the closure uses `SetLevel(Level)`.
 func testSetLevelByLevel(t *testing.T, testCaseName string, level Level, expectedLogSeriesForLevelString string) {
+	// This has to be done before `New()` so that the new logger will output to
+	// the stdout fake.
+	resetStdoutFake(t)
+
 	logger := New()
 
 	var setLevelClosure setLevelFunction
@@ -169,6 +207,10 @@ func testSetLevelByLevel(t *testing.T, testCaseName string, level Level, expecte
 // level without needing to know which setter to use and what level is being
 // specified.  In this case, the closure uses `SetLevelByLevelString(string)`.
 func testSetLevelByLevelString(t *testing.T, testCaseName string, levelString string, expectedLogSeriesForLevelString string) {
+	// This has to be done before `New()` so that the new logger will output to
+	// the stdout fake.
+	resetStdoutFake(t)
+
 	logger := New()
 
 	var setLevelClosure setLevelFunction
@@ -191,11 +233,6 @@ func testSetLevelByLevelString(t *testing.T, testCaseName string, levelString st
 // that differ only by a single statement: e.g. `SetLevel(...)`vs. `SetLevelByString(...)`.
 func testSetLevel(t *testing.T, logger Logger, setLevelFunctionName string,
 	setLevelClosure setLevelFunction, testCaseName string, expectedLogSeriesString string) {
-	// Capture all log output in a `bytes.Buffer`.
-	var logOutput bytes.Buffer
-	logOutputWriter := bufio.NewWriter(&logOutput)
-	logger.SetOutput(logOutputWriter)
-
 	// We've been provided a set level function which has been closed off with the
 	// desired level.  We just need to call it to set the package log level.
 	setLevelClosure()
@@ -203,10 +240,15 @@ func testSetLevel(t *testing.T, logger Logger, setLevelFunctionName string,
 	// Logs simple messages for each testCase in ascending order of severity.
 	logSeries(logger)
 
-	// Must flush the writer to prevent risk truncation of `logOutput`
-	err := logOutputWriter.Flush()
+	// `os.Stdout` was already replaced by `stdoutFakeWriteFile` earlier on.
+	// Close it and get everything that was logged to it.
+	err := stdoutFakeWriteFile.Close()
 	if err != nil {
-		t.Fatalf("Error calling `logOutputWriter.Flush`: %s", err)
+		t.Fatalf("w.Close() failed with error: %s", err)
+	}
+	logOutput, err := io.ReadAll(stdoutFakeReadFile)
+	if err != nil {
+		t.Fatalf("io.ReadAll(r) failed with error: %s", err)
 	}
 
 	// Example of actual log series string to be compared against the expected log series string:
@@ -215,7 +257,7 @@ func testSetLevel(t *testing.T, logger Logger, setLevelFunctionName string,
 	// INFO|info
 	// WARN|warn
 	// ERROR|error
-	actualLogSeriesString := getLogSeriesString(logOutput.String())
+	actualLogSeriesString := getLogSeriesString(string(logOutput))
 
 	// Example output for a bug where LevelError is accidentally mapped to slog.LevelWarn
 	// (this is a real bug that was caught by this test):


### PR DESCRIPTION
* Fix the totally broken `log.SetLevel{ByString}` methods and `testSetLevel()` which was returning false negatives due to using `SetOutput()` which did the correct `sl.slogger` replacement that the `SetLevel{ByString}` methods were not doing.
* Add test for `SetOutput()` since it's not being used by `testSetLevel()` anymore (and thus no free regression testing).  Note that `SetOutput()` is not being used in go-ead-indexer project, but it was used in `ariadne` and is useful to have in a general purpose package.