### PR TITLE
Remove special case DLFA_238 comment related to DLFA-277

### DIFF
--- a/pkg/ead/component/set-containers-part.go
+++ b/pkg/ead/component/set-containers-part.go
@@ -42,31 +42,6 @@ func makeContainer(containerNode types.Node) (Container, error) {
 	if err == nil {
 		container.Type = typeAttributeNode.Value()
 	} else if err.Error() == "attribute not found" {
-		// TODO: DLFA-238
-		// This is a unique DLFA_238 case, in that we have identified a DLFA-211
-		// bug, but the specifics of what the bug is depends on whether stakeholders
-		// consider the `type` attribute to be required in the <container> element
-		// or not required, and if the former, whether that invalidates the entire
-		// EAD file.  For details, see:
-		// 	  * https://jira.nyu.edu/browse/DLFA-277
-		//        * "Debug indexer error "attribute not found" for tamwag/aia_003.xml"
-		//    * https://jira.nyu.edu/browse/DLFA-211?focusedCommentId=11923734&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-11923734
-		//        * "[bug] Missing <container> attribute `type` leads to ": " at beginning of <location_ssm> and <location_ssi> values"
-		// For now we are matching v1 indexer's behavior of not invalidating the
-		// <container> and making `location_ssm` and `location_si` Solr fields
-		// as best we can.  The v1 indexer looks to be doing this by accident,
-		// and adds ": " to the beginning of the field values.  We will strip out
-		// this erroneous blank `type` intro string, abd instead just use an empty
-		// string to represent a missing `type`.
-		// The DLFA-238 steps will be one of these options:
-		//     * Keep this code as-is and add a golden file test for tamwag/aia_003.
-		//     * Use some other handling non-fatal handling for missing `type`.
-		//         * Use a label/intro like "[Type unspecified]: "
-		//         * Keep code as-is but but `log.Warn()` (would need to enable `warn` logging level)
-		//     * Remove this code and let the EAD file fail completely and return a more comprehensible wrapped error.
-		//         * Note that we will probably do an error reporting overhaul,
-		//        	 so might want to hold off on crafting the "perfect" error.
-		//     * Something else
 		container.Type = ""
 	} else {
 		return container, err


### PR DESCRIPTION
Removed a special case [DLFA-238](https://jira.nyu.edu/browse/DLFA-238) TODO comment that explained why had not yet finalized the [DLFA-277](https://jira.nyu.edu/browse/DLFA-277) bugfix.  In part this was because we were not yet sure if stakeholders would consider it a bug or not, because v1 indexer's handling of this edge case appears to be sheerly accidental.  (See related [DLFA-211 bug report](https://jira.nyu.edu/browse/DLFA-211?focusedCommentId=11923734&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-11923734)).

This PR removes a comment only, there are no code changes at all, and thus no behavioral/functional changes.