### PR TITLE
pkg/ead/ead_test.go bugfix: if `--update-golden-files`, delete golden files for `missingComponents` instead of reporting a false positive

### DIFF
--- a/pkg/ead/ead_test.go
+++ b/pkg/ead/ead_test.go
@@ -222,12 +222,21 @@ func testNoMissingComponents(testEAD string, componentIDs []string, t *testing.T
 	}
 
 	if len(missingComponents) > 0 {
-		slices.SortStableFunc(missingComponents, func(a string, b string) int {
-			return strings.Compare(a, b)
-		})
-		failMessage := fmt.Sprintf("`EAD.Components` for testEAD %s is missing the following component IDs:\n%s",
-			testEAD, strings.Join(missingComponents, "\n"))
-		t.Error(failMessage)
+		if *updateGoldenFiles {
+			for _, missingComponent := range missingComponents {
+				err := testutils.DeleteGoldenFile(testEAD, missingComponent)
+				if err != nil {
+					t.Fatalf("Error deleting golden file: %s", err)
+				}
+			}
+		} else {
+			slices.SortStableFunc(missingComponents, func(a string, b string) int {
+				return strings.Compare(a, b)
+			})
+			failMessage := fmt.Sprintf("`EAD.Components` for testEAD %s is missing the following component IDs:\n%s",
+				testEAD, strings.Join(missingComponents, "\n"))
+			t.Error(failMessage)
+		}
 	}
 }
 

--- a/pkg/ead/testutils/testutils.go
+++ b/pkg/ead/testutils/testutils.go
@@ -36,6 +36,10 @@ func init() {
 	goldenFilesDirPath = filepath.Join(testutilsPath, "..", "testdata", "golden")
 }
 
+func DeleteGoldenFile(testEAD string, fileID string) error {
+	return os.Remove(GoldenFilePath(testEAD, fileID))
+}
+
 func EadFixturePath(testEAD string) string {
 	return filepath.Join(eadFixturesDirPath, testEAD+".xml")
 }


### PR DESCRIPTION
Jira: [DLFA-323: go\-ead\-indexer: ead\_test\.go false positive when running tests with \`\-\-update\-golden\-files\` after removing a <c> from EAD fixture](https://nyu.atlassian.net/browse/DLFA-323)